### PR TITLE
Update: 去掉Upload组件内默认的Content-Type设置，否则上传文件的xhr请求有bug

### DIFF
--- a/src/Uploader/Uploader.js
+++ b/src/Uploader/Uploader.js
@@ -72,9 +72,7 @@ FileUploader.prototype.init = function () {
 FileUploader.prototype.upload = function () {
     if (this.opt['before-upload'](this.file) && !this.file.uploaded) {
         this.xhr.open('POST', this.opt.action);
-        method.repeatSet(Object.assign({
-            'Content-Type': 'application/x-www-form-urlencoded'
-        }, this.opt.headers), this.xhr.setRequestHeader.bind(this.xhr));
+        method.repeatSet(this.opt.headers, this.xhr.setRequestHeader.bind(this.xhr));
         this.xhr.send(this.formData);
     }
 };


### PR DESCRIPTION
Content-Type在 send() 时会自动添加， 无需手动添加，若覆盖当前Content-Type为multipart/form-data, 则请求将缺少 boundary，后端无法正确解析拿到上传数据。bug详情见https://stackoverflow.com/questions/18590630/xmlhttprequest-multipart-form-data-invalid-boundary-in-multipart